### PR TITLE
Update Gemini.php

### DIFF
--- a/src/Gemini.php
+++ b/src/Gemini.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Gemini;
+
 use Gemini\Client;
 use Gemini\Factory;
 


### PR DESCRIPTION
Added missing namespace declaration, I think  use Gemini\Client; and use Gemini\Factory; can be removed now as well.