### PR TITLE
feat: usageMetadata in GenerateContentResponse

### DIFF
--- a/src/Data/UsageMetadata.php
+++ b/src/Data/UsageMetadata.php
@@ -12,16 +12,15 @@ use Gemini\Contracts\Arrayable;
 final class UsageMetadata implements Arrayable
 {
     /**
-     * @param int $promptTokenCount The number of tokens in the prompt.
-     * @param int $candidatesTokenCount The number of tokens in the generated candidates.
-     * @param int $totalTokenCount The total number of tokens used.
+     * @param  int  $promptTokenCount  The number of tokens in the prompt.
+     * @param  int  $candidatesTokenCount  The number of tokens in the generated candidates.
+     * @param  int  $totalTokenCount  The total number of tokens used.
      */
     public function __construct(
         public readonly int $promptTokenCount,
         public readonly int $candidatesTokenCount,
         public readonly int $totalTokenCount,
-    ) {
-    }
+    ) {}
 
     /**
      * @param array{

--- a/src/Data/UsageMetadata.php
+++ b/src/Data/UsageMetadata.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gemini\Data;
+
+use Gemini\Contracts\Arrayable;
+
+/**
+ * Metadata about token usage in the API response.
+ */
+final class UsageMetadata implements Arrayable
+{
+    /**
+     * @param int $promptTokenCount The number of tokens in the prompt.
+     * @param int $candidatesTokenCount The number of tokens in the generated candidates.
+     * @param int $totalTokenCount The total number of tokens used.
+     */
+    public function __construct(
+        public readonly int $promptTokenCount,
+        public readonly int $candidatesTokenCount,
+        public readonly int $totalTokenCount,
+    ) {
+    }
+
+    /**
+     * @param array{
+     *     promptTokenCount: int,
+     *     candidatesTokenCount: int,
+     *     totalTokenCount: int
+     * } $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            promptTokenCount: $attributes['promptTokenCount'],
+            candidatesTokenCount: $attributes['candidatesTokenCount'],
+            totalTokenCount: $attributes['totalTokenCount'],
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'promptTokenCount' => $this->promptTokenCount,
+            'candidatesTokenCount' => $this->candidatesTokenCount,
+            'totalTokenCount' => $this->totalTokenCount,
+        ];
+    }
+}

--- a/src/Resources/GenerativeModel.php
+++ b/src/Resources/GenerativeModel.php
@@ -76,7 +76,7 @@ final class GenerativeModel implements GenerativeModelContract
      */
     public function generateContent(string|Blob|array|Content ...$parts): GenerateContentResponse
     {
-        /** @var ResponseDTO<array{ candidates: ?array{ array{ content: array{ parts: array{ array{ text: ?string, inlineData: array{ mimeType: string, data: string } } }, role: string }, finishReason: string, safetyRatings: array{ array{ category: string, probability: string, blocked: ?bool } }, citationMetadata: ?array{ citationSources: array{ array{ startIndex: int, endIndex: int, uri: string, license: string} } }, index: int, tokenCount: ?int } }, promptFeedback: ?array{ safetyRatings: array{ array{ category: string, probability: string, blocked: ?bool } }, blockReason: ?string } }> $response */
+        /** @var ResponseDTO<array{ candidates: ?array{ array{ content: array{ parts: array{ array{ text: ?string, inlineData: array{ mimeType: string, data: string } } }, role: string }, finishReason: string, safetyRatings: array{ array{ category: string, probability: string, blocked: ?bool } }, citationMetadata: ?array{ citationSources: array{ array{ startIndex: int, endIndex: int, uri: string, license: string} } }, index: int, tokenCount: ?int } }, promptFeedback: ?array{ safetyRatings: array{ array{ category: string, probability: string, blocked: ?bool } }, blockReason: ?string } , usageMetadata: array{promptTokenCount: int, candidatesTokenCount: int, totalTokenCount: int} }> $response */
         $response = $this->transporter->request(
             request: new GenerateContentRequest(
                 model: $this->model,

--- a/src/Responses/GenerativeModel/GenerateContentResponse.php
+++ b/src/Responses/GenerativeModel/GenerateContentResponse.php
@@ -89,7 +89,7 @@ final class GenerateContentResponse implements ResponseContract
     }
 
     /**
-     * @param  array{ candidates: ?array{ array{ content: array{ parts: array{ array{ text: ?string, inlineData: array{ mimeType: string, data: string } } }, role: string }, finishReason: string, safetyRatings: array{ array{ category: string, probability: string, blocked: ?bool } }, citationMetadata: ?array{ citationSources: array{ array{ startIndex: int, endIndex: int, uri: string, license: string} } }, index: int, tokenCount: ?int } }, promptFeedback: ?array{ safetyRatings: array{ array{ category: string, probability: string, blocked: ?bool } }, blockReason: ?string }, usageMetadata: ["promptTokenCount": int, "candidatesTokenCount": int, "totalTokenCount": int] }  $attributes
+     * @param  array{ candidates: ?array{ array{ content: array{ parts: array{ array{ text: ?string, inlineData: array{ mimeType: string, data: string } } }, role: string }, finishReason: string, safetyRatings: array{ array{ category: string, probability: string, blocked: ?bool } }, citationMetadata: ?array{ citationSources: array{ array{ startIndex: int, endIndex: int, uri: string, license: string} } }, index: int, tokenCount: ?int } }, promptFeedback: ?array{ safetyRatings: array{ array{ category: string, probability: string, blocked: ?bool } }, blockReason: ?string }, usageMetadata: array{promptTokenCount: int, candidatesTokenCount: int, totalTokenCount: int} }  $attributes
      */
     public static function from(array $attributes): self
     {

--- a/src/Responses/GenerativeModel/GenerateContentResponse.php
+++ b/src/Responses/GenerativeModel/GenerateContentResponse.php
@@ -32,8 +32,7 @@ final class GenerateContentResponse implements ResponseContract
         public readonly array $candidates,
         public readonly ?PromptFeedback $promptFeedback = null,
         public readonly ?UsageMetadata $usageMetadata = null,
-    ) {
-    }
+    ) {}
 
     /**
      * A quick accessor equivalent to `$candidates[0]->content->parts`
@@ -89,7 +88,7 @@ final class GenerateContentResponse implements ResponseContract
     }
 
     /**
-     * @param  array{ candidates: ?array{ array{ content: array{ parts: array{ array{ text: ?string, inlineData: array{ mimeType: string, data: string } } }, role: string }, finishReason: string, safetyRatings: array{ array{ category: string, probability: string, blocked: ?bool } }, citationMetadata: ?array{ citationSources: array{ array{ startIndex: int, endIndex: int, uri: string, license: string} } }, index: int, tokenCount: ?int } }, promptFeedback: ?array{ safetyRatings: array{ array{ category: string, probability: string, blocked: ?bool } }, blockReason: ?string }, usageMetadata: array{promptTokenCount: int, candidatesTokenCount: int, totalTokenCount: int} }  $attributes
+     * @param  array{ candidates: ?array{ array{ content: array{ parts: array{ array{ text: ?string, inlineData: array{ mimeType: string, data: string } } }, role: string }, finishReason: string, safetyRatings: array{ array{ category: string, probability: string, blocked: ?bool } }, citationMetadata: ?array{ citationSources: array{ array{ startIndex: int, endIndex: int, uri: string, license: string} } }, index: int, tokenCount: ?int } }, promptFeedback: ?array{ safetyRatings: array{ array{ category: string, probability: string, blocked: ?bool } }, blockReason: ?string }, usageMetadata: ?array{promptTokenCount: int, candidatesTokenCount: int, totalTokenCount: int} }  $attributes
      */
     public static function from(array $attributes): self
     {

--- a/src/Responses/GenerativeModel/GenerateContentResponse.php
+++ b/src/Responses/GenerativeModel/GenerateContentResponse.php
@@ -8,6 +8,7 @@ use Gemini\Contracts\ResponseContract;
 use Gemini\Data\Candidate;
 use Gemini\Data\Part;
 use Gemini\Data\PromptFeedback;
+use Gemini\Data\UsageMetadata;
 use Gemini\Testing\Responses\Concerns\Fakeable;
 use Gemini\Testing\Responses\Concerns\FakeableForStreamedResponse;
 use ValueError;
@@ -25,10 +26,12 @@ final class GenerateContentResponse implements ResponseContract
     /**
      * @param  array<Candidate>  $candidates  Candidate responses from the model.
      * @param  PromptFeedback  $promptFeedback  Returns the prompt's feedback related to the content filters.
+     * @param  UsageMetadata  $usageMetadata  Returns the usage metadata for the response.
      */
     public function __construct(
         public readonly array $candidates,
         public readonly ?PromptFeedback $promptFeedback = null,
+        public readonly ?UsageMetadata $usageMetadata = null,
     ) {
     }
 
@@ -86,7 +89,7 @@ final class GenerateContentResponse implements ResponseContract
     }
 
     /**
-     * @param  array{ candidates: ?array{ array{ content: array{ parts: array{ array{ text: ?string, inlineData: array{ mimeType: string, data: string } } }, role: string }, finishReason: string, safetyRatings: array{ array{ category: string, probability: string, blocked: ?bool } }, citationMetadata: ?array{ citationSources: array{ array{ startIndex: int, endIndex: int, uri: string, license: string} } }, index: int, tokenCount: ?int } }, promptFeedback: ?array{ safetyRatings: array{ array{ category: string, probability: string, blocked: ?bool } }, blockReason: ?string } }  $attributes
+     * @param  array{ candidates: ?array{ array{ content: array{ parts: array{ array{ text: ?string, inlineData: array{ mimeType: string, data: string } } }, role: string }, finishReason: string, safetyRatings: array{ array{ category: string, probability: string, blocked: ?bool } }, citationMetadata: ?array{ citationSources: array{ array{ startIndex: int, endIndex: int, uri: string, license: string} } }, index: int, tokenCount: ?int } }, promptFeedback: ?array{ safetyRatings: array{ array{ category: string, probability: string, blocked: ?bool } }, blockReason: ?string }, usageMetadata: ["promptTokenCount": int, "candidatesTokenCount": int, "totalTokenCount": int] }  $attributes
      */
     public static function from(array $attributes): self
     {
@@ -100,9 +103,14 @@ final class GenerateContentResponse implements ResponseContract
             default => null
         };
 
+        $usageMetadata = isset($attributes['usageMetadata'])
+            ? UsageMetadata::from($attributes['usageMetadata'])
+            : null;
+
         return new self(
             candidates: $candidates,
-            promptFeedback: $promptFeedback
+            promptFeedback: $promptFeedback,
+            usageMetadata: $usageMetadata
         );
     }
 
@@ -114,6 +122,7 @@ final class GenerateContentResponse implements ResponseContract
                 $this->candidates
             ),
             'promptFeedback' => $this->promptFeedback?->toArray(),
+            'usageMetadata' => $this->usageMetadata?->toArray(),
         ];
     }
 }


### PR DESCRIPTION
# Context
Google's `GenerateContentResponse` includes a "[usageMetadata](https://ai.google.dev/api/generate-content#usagemetadata)".

The above has reference to 4 attributes of the usageMetadata, however the actual returned response currently only includes the 3 listed [here in their API Reference](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/nodejs/latest/vertexai/usagemetadata). The raw response was checked and tested to ensure this.

This contains useful information about the:
* Number of response tokens used
* Number of tokens in the prompt
* Total number of tokens.

# Changes
This involved the creation of the `UsageMetadata` class, and modifications to the `GenerateContentResponse` class.

## `UsageMetadata` Creation
This class implements the [UsageMetadata (1.4.1)](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/nodejs/latest/vertexai/usagemetadata) response as per the Gemini API.

## `GenerateContentResponse` Changes
Integrated the new UsageMetadata class to include these.