### PR TITLE
Update UsageMetadata.php

### DIFF
--- a/src/Data/UsageMetadata.php
+++ b/src/Data/UsageMetadata.php
@@ -20,9 +20,9 @@ final class UsageMetadata implements Arrayable
      * @param  int|null  $cachedContentTokenCount  Number of tokens in the cached part of the prompt (the cached content)
      */
     public function __construct(
-        public readonly int $promptTokenCount,
+        public readonly ?int $promptTokenCount = null,
         public readonly ?int $candidatesTokenCount = null,
-        public readonly int $totalTokenCount,
+        public readonly ?int $totalTokenCount = null,
         public readonly ?int $cachedContentTokenCount = null,
     ) {}
 
@@ -32,9 +32,9 @@ final class UsageMetadata implements Arrayable
     public static function from(array $attributes): self
     {
         return new self(
-            promptTokenCount: $attributes['promptTokenCount'],
+            promptTokenCount: $attributes['promptTokenCount'] ?? null,
             candidatesTokenCount: $attributes['candidatesTokenCount'] ?? null,
-            totalTokenCount: $attributes['totalTokenCount'],
+            totalTokenCount: $attributes['totalTokenCount'] ?? null,
             cachedContentTokenCount: $attributes['cachedContentTokenCount'] ?? null
         );
     }


### PR DESCRIPTION
The previous changes in #37 introduced a deprecated warning: `DEPRECATED Optional parameter $candidatesTokenCount declared before required parameter $totalTokenCount.`

To fix this, I think we have to make all the parameters nullable; reordering the parameters will introduce a breaking change.