### PR TITLE
Update UsageMetadata.php fixing deprecation alert

### DIFF
--- a/src/Data/UsageMetadata.php
+++ b/src/Data/UsageMetadata.php
@@ -21,8 +21,8 @@ final class UsageMetadata implements Arrayable
      */
     public function __construct(
         public readonly int $promptTokenCount,
-        public readonly ?int $candidatesTokenCount = null,
         public readonly int $totalTokenCount,
+        public readonly ?int $candidatesTokenCount = null,
         public readonly ?int $cachedContentTokenCount = null,
     ) {}
 


### PR DESCRIPTION
Required parameter $totalTokenCount follows optional parameter $candidatesTokenCount