### PR TITLE
Support for tuned models

### DIFF
--- a/src/Concerns/HasModel.php
+++ b/src/Concerns/HasModel.php
@@ -13,7 +13,8 @@ trait HasModel
     {
         return match (true) {
             $model instanceof BackedEnum => $model->value,
-            str_starts_with($model, 'models') => $model,
+            str_starts_with($model, 'models/') => $model,
+            str_starts_with($model, 'tunedModels/') => $model,
             default => "models/$model"
         };
     }


### PR DESCRIPTION
To support [fine-tuned models](https://ai.google.dev/gemini-api/docs/model-tuning), we can't prepend `models/` to the model name. Fine-tuned models start with `tunedModels/`, so just checking for this is enough.