### PR TITLE
feat: Add system promt support for beta

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -7,9 +7,6 @@ namespace Gemini;
 use Gemini\Contracts\ClientContract;
 use Gemini\Contracts\Resources\GenerativeModelContract;
 use Gemini\Contracts\TransporterContract;
-use Gemini\Data\Content;
-use Gemini\Data\GenerationConfig;
-use Gemini\Data\Model;
 use Gemini\Enums\ModelType;
 use Gemini\Resources\ChatSession;
 use Gemini\Resources\EmbeddingModel;
@@ -31,19 +28,9 @@ final class Client implements ClientContract
         return new Models(transporter: $this->transporter);
     }
 
-    public function generativeModel(
-        ModelType|string $model,
-        array $safetySettings = [],
-        ?GenerationConfig $generationConfig = null,
-        ?Content $systemInstruction = null
-    ): GenerativeModel {
-        return new GenerativeModel(
-            transporter: $this->transporter,
-            model: $model,
-            safetySettings: $safetySettings,
-            generationConfig: $generationConfig,
-            systemInstruction: $systemInstruction
-        );
+    public function generativeModel(ModelType|string $model): GenerativeModel
+    {
+        return new GenerativeModel(transporter: $this->transporter, model: $model);
     }
 
     public function geminiPro(): GenerativeModel

--- a/src/Client.php
+++ b/src/Client.php
@@ -7,6 +7,8 @@ namespace Gemini;
 use Gemini\Contracts\ClientContract;
 use Gemini\Contracts\Resources\GenerativeModelContract;
 use Gemini\Contracts\TransporterContract;
+use Gemini\Data\Content;
+use Gemini\Data\GenerationConfig;
 use Gemini\Data\Model;
 use Gemini\Enums\ModelType;
 use Gemini\Resources\ChatSession;
@@ -29,9 +31,19 @@ final class Client implements ClientContract
         return new Models(transporter: $this->transporter);
     }
 
-    public function generativeModel(ModelType|string $model): GenerativeModel
-    {
-        return new GenerativeModel(transporter: $this->transporter, model: $model);
+    public function generativeModel(
+        ModelType|string $model,
+        array $safetySettings = [],
+        ?GenerationConfig $generationConfig = null,
+        ?Content $systemInstruction = null
+    ): GenerativeModel {
+        return new GenerativeModel(
+            transporter: $this->transporter,
+            model: $model,
+            safetySettings: $safetySettings,
+            generationConfig: $generationConfig,
+            systemInstruction: $systemInstruction
+        );
     }
 
     public function geminiPro(): GenerativeModel

--- a/src/Contracts/Resources/GenerativeModelContract.php
+++ b/src/Contracts/Resources/GenerativeModelContract.php
@@ -29,6 +29,8 @@ interface GenerativeModelContract
      */
     public function streamGenerateContent(string|Blob|array|Content ...$parts): StreamResponse;
 
+    public function withSystemInstruction(Content $systemInstruction): self;
+
     /**
      * @param  array<Content>  $history
      */

--- a/src/Requests/GenerativeModel/GenerateContentRequest.php
+++ b/src/Requests/GenerativeModel/GenerateContentRequest.php
@@ -28,7 +28,8 @@ class GenerateContentRequest extends Request
         protected readonly string $model,
         protected readonly array $parts,
         protected readonly array $safetySettings = [],
-        protected readonly ?GenerationConfig $generationConfig = null
+        protected readonly ?GenerationConfig $generationConfig = null,
+        protected readonly ?Content $systemInstruction = null
     ) {}
 
     public function resolveEndpoint(): string
@@ -43,7 +44,7 @@ class GenerateContentRequest extends Request
      */
     protected function defaultBody(): array
     {
-        return [
+        $body = [
             'contents' => array_map(
                 static fn (Content $content): array => $content->toArray(),
                 $this->partsToContents(...$this->parts)
@@ -54,5 +55,11 @@ class GenerateContentRequest extends Request
             ),
             'generationConfig' => $this->generationConfig?->toArray(),
         ];
+
+        if ($this->systemInstruction !== null) {
+            $body['system_instruction'] = $this->systemInstruction->toArray();
+        }
+
+        return $body;
     }
 }

--- a/src/Requests/GenerativeModel/GenerateContentRequest.php
+++ b/src/Requests/GenerativeModel/GenerateContentRequest.php
@@ -44,7 +44,7 @@ class GenerateContentRequest extends Request
      */
     protected function defaultBody(): array
     {
-        $body = [
+        return [
             'contents' => array_map(
                 static fn (Content $content): array => $content->toArray(),
                 $this->partsToContents(...$this->parts)
@@ -54,12 +54,7 @@ class GenerateContentRequest extends Request
                 $this->safetySettings ?? []
             ),
             'generationConfig' => $this->generationConfig?->toArray(),
+            'systemInstruction' => $this->systemInstruction?->toArray(),
         ];
-
-        if ($this->systemInstruction !== null) {
-            $body['system_instruction'] = $this->systemInstruction->toArray();
-        }
-
-        return $body;
     }
 }

--- a/src/Resources/GenerativeModel.php
+++ b/src/Resources/GenerativeModel.php
@@ -34,6 +34,7 @@ final class GenerativeModel implements GenerativeModelContract
         ModelType|string $model,
         public array $safetySettings = [],
         public ?GenerationConfig $generationConfig = null,
+        public ?Content $systemInstruction = null,
     ) {
         $this->model = $this->parseModel(model: $model);
     }
@@ -48,6 +49,13 @@ final class GenerativeModel implements GenerativeModelContract
     public function withGenerationConfig(GenerationConfig $generationConfig): self
     {
         $this->generationConfig = $generationConfig;
+
+        return $this;
+    }
+
+    public function withSystemInstruction(Content $systemInstruction): self
+    {
+        $this->systemInstruction = $systemInstruction;
 
         return $this;
     }
@@ -83,6 +91,7 @@ final class GenerativeModel implements GenerativeModelContract
                 parts: $parts,
                 safetySettings: $this->safetySettings,
                 generationConfig: $this->generationConfig,
+                systemInstruction: $this->systemInstruction,
             )
         );
 

--- a/src/Testing/Resources/GenerativeModelTestResource.php
+++ b/src/Testing/Resources/GenerativeModelTestResource.php
@@ -42,4 +42,9 @@ final class GenerativeModelTestResource implements GenerativeModelContract
     {
         return $this->record(method: __FUNCTION__, args: func_get_args(), model: $this->model);
     }
+
+    public function withSystemInstruction(Content $systemInstruction): self
+    {
+        return $this->record(method: __FUNCTION__, args: func_get_args(), model: $this->model);
+    }
 }

--- a/tests/Resources/GenerativeModel.php
+++ b/tests/Resources/GenerativeModel.php
@@ -212,9 +212,9 @@ test('generative model with system instruction', function () {
 
     expect($body)
         ->toHaveKey('contents')
-        ->toHaveKey('system_instruction')
+        ->toHaveKey('systemInstruction')
         ->and($body['contents'][0]['parts'][0]['text'])->toBe($userMessage)
-        ->and($body['system_instruction']['parts'][0]['text'])->toBe($systemInstruction);
+        ->and($body['systemInstruction']['parts'][0]['text'])->toBe($systemInstruction);
 
     expect($model)
         ->toHaveProperty('systemInstruction')
@@ -233,7 +233,7 @@ test('system instruction is included in the request', function () {
             $body = $request->body();
 
             return $body['contents'][0]['parts'][0]['text'] === 'Hello' &&
-                $body['system_instruction']['parts'][0]['text'] === $systemInstruction;
+                $body['systemInstruction']['parts'][0]['text'] === $systemInstruction;
         })
         ->andReturn(new ResponseDTO(GenerateContentResponse::fake()->toArray()));
 

--- a/tests/Resources/GenerativeModel.php
+++ b/tests/Resources/GenerativeModel.php
@@ -1,6 +1,8 @@
 <?php
 
+use Gemini\Client;
 use Gemini\Data\Candidate;
+use Gemini\Data\Content;
 use Gemini\Data\GenerationConfig;
 use Gemini\Data\PromptFeedback;
 use Gemini\Data\SafetySetting;
@@ -13,6 +15,7 @@ use Gemini\Resources\ChatSession;
 use Gemini\Responses\GenerativeModel\CountTokensResponse;
 use Gemini\Responses\GenerativeModel\GenerateContentResponse;
 use Gemini\Responses\StreamResponse;
+use Gemini\Transporters\DTOs\ResponseDTO;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Stream;
 
@@ -177,4 +180,68 @@ test('start chat for custom model', function () {
 
     expect($result)
         ->toBeInstanceOf(ChatSession::class);
+});
+
+test('generative model with system instruction', function () {
+    $modelType = ModelType::GEMINI_PRO;
+    $systemInstruction = 'You are a helpful assistant.';
+    $userMessage = 'Hello';
+
+    $mockTransporter = Mockery::mock(\Gemini\Contracts\TransporterContract::class);
+    $mockTransporter->shouldReceive('request')
+        ->once()
+        ->andReturnUsing(function ($request) use (&$capturedRequest) {
+            $capturedRequest = $request;
+
+            return new ResponseDTO(GenerateContentResponse::fake()->toArray());
+        });
+
+    $client = new Client($mockTransporter);
+    $model = $client->generativeModel(model: $modelType)
+        ->withSystemInstruction(Content::parse($systemInstruction));
+
+    $result = $model->generateContent($userMessage);
+
+    expect($result)->toBeInstanceOf(GenerateContentResponse::class);
+
+    expect($capturedRequest)
+        ->toBeInstanceOf(\Gemini\Requests\GenerativeModel\GenerateContentRequest::class)
+        ->and($capturedRequest->resolveEndpoint())->toBe("{$modelType->value}:generateContent");
+
+    $body = $capturedRequest->body();
+
+    expect($body)
+        ->toHaveKey('contents')
+        ->toHaveKey('system_instruction')
+        ->and($body['contents'][0]['parts'][0]['text'])->toBe($userMessage)
+        ->and($body['system_instruction']['parts'][0]['text'])->toBe($systemInstruction);
+
+    expect($model)
+        ->toHaveProperty('systemInstruction')
+        ->and($model->systemInstruction)->toBeInstanceOf(Content::class)
+        ->and($model->systemInstruction->parts[0]->text)->toBe($systemInstruction);
+});
+
+test('system instruction is included in the request', function () {
+    $modelType = ModelType::GEMINI_PRO;
+    $systemInstruction = 'You are a helpful assistant.';
+
+    $mockTransporter = Mockery::mock(\Gemini\Contracts\TransporterContract::class);
+    $mockTransporter->shouldReceive('request')
+        ->once()
+        ->withArgs(function (\Gemini\Requests\GenerativeModel\GenerateContentRequest $request) use ($systemInstruction) {
+            $body = $request->body();
+
+            return $body['contents'][0]['parts'][0]['text'] === 'Hello' &&
+                $body['system_instruction']['parts'][0]['text'] === $systemInstruction;
+        })
+        ->andReturn(new ResponseDTO(GenerateContentResponse::fake()->toArray()));
+
+    $client = new \Gemini\Client($mockTransporter);
+
+    $parsedSystemInstruction = Content::parse($systemInstruction);
+    $generativeModel = $client->generativeModel(model: $modelType)
+        ->withSystemInstruction($parsedSystemInstruction);
+
+    $generativeModel->generateContent('Hello');
 });


### PR DESCRIPTION
This is almost 1:1 copy of @gregpriday PR:[https://github.com/google-gemini-php/client/pull/42]( https://github.com/google-gemini-php/client/pull/42), but added on **beta** branch instead of **main**.

This PR introduces [system instruction](https://ai.google.dev/gemini-api/docs/system-instructions?lang=rest) support and adds the ability to easily configure the client to use the beta API endpoint (required for system instructions).

### Changes

1. System Instruction Support:
    - Added withSystemInstruction method to the GenerativeModel class
    - Updated GenerateContentRequest and related components to include system instructions in API requests
    - Modified Client and GenerativeModelContract to support system instructions
    - Added tests to verify system instruction functionality
   
2. Added tests to cover the new beta API configuration

Additional Notes:

- The code follows the project's coding style (verified using composer lint)
- Tests have been added for the new functionality
- The commit history is coherent and meaningful
- No breaking changes have been introduced, maintaining SemVer compatibility
- Tested in my own project, and everything is working properly
- Please review and let me know if any further changes are needed.