### PR TITLE
Align `GenerativeModelTestResource` with `GenerativeModel`

### DIFF
--- a/src/Contracts/Resources/GenerativeModelContract.php
+++ b/src/Contracts/Resources/GenerativeModelContract.php
@@ -6,6 +6,8 @@ namespace Gemini\Contracts\Resources;
 
 use Gemini\Data\Blob;
 use Gemini\Data\Content;
+use Gemini\Data\GenerationConfig;
+use Gemini\Data\SafetySetting;
 use Gemini\Resources\ChatSession;
 use Gemini\Responses\GenerativeModel\CountTokensResponse;
 use Gemini\Responses\GenerativeModel\GenerateContentResponse;
@@ -33,4 +35,8 @@ interface GenerativeModelContract
      * @param  array<Content>  $history
      */
     public function startChat(array $history = []): ChatSession;
+
+    public function withSafetySetting(SafetySetting $safetySetting): self;
+
+    public function withGenerationConfig(GenerationConfig $generationConfig): self;
 }

--- a/src/Testing/FunctionCalls/TestFunctionCall.php
+++ b/src/Testing/FunctionCalls/TestFunctionCall.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gemini\Testing\FunctionCalls;
+
+use Gemini\Enums\ModelType;
+
+final class TestFunctionCall
+{
+    /**
+     * @param  array<string, mixed>  $args
+     */
+    public function __construct(protected string $resource, protected string $method, protected array $args, protected ModelType|string|null $model = null) {}
+
+    public function resource(): string
+    {
+        return $this->resource;
+    }
+
+    public function method(): string
+    {
+        return $this->method;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function args(): array
+    {
+        return $this->args;
+    }
+
+    public function model(): ModelType|string|null
+    {
+        return $this->model;
+    }
+}

--- a/src/Testing/Resources/Concerns/Testable.php
+++ b/src/Testing/Resources/Concerns/Testable.php
@@ -8,6 +8,7 @@ use Gemini\Contracts\ResponseContract;
 use Gemini\Enums\ModelType;
 use Gemini\Responses\StreamResponse;
 use Gemini\Testing\ClientFake;
+use Gemini\Testing\FunctionCalls\TestFunctionCall;
 use Gemini\Testing\Requests\TestRequest;
 
 trait Testable
@@ -29,5 +30,20 @@ trait Testable
     public function assertNotSent(callable|int|null $callback = null): void
     {
         $this->fake->assertNotSent(resource: $this->resource(), model: $this->model, callback: $callback);
+    }
+
+    public function recordFunctionCall(string $method, array $args = [], ModelType|string|null $model = null): void
+    {
+        $this->fake->recordFunctionCall(new TestFunctionCall(resource: $this->resource(), method: $method, args: $args, model: $model));
+    }
+
+    public function assertFunctionCalled(callable|int|null $callback = null): void
+    {
+        $this->fake->assertFunctionCalled(resource: $this->resource(), model: $this->model, callback: $callback);
+    }
+
+    public function assertFunctionNotCalled(callable|int|null $callback = null): void
+    {
+        $this->fake->assertFunctionNotCalled(resource: $this->resource(), model: $this->model, callback: $callback);
     }
 }

--- a/src/Testing/Resources/GenerativeModelTestResource.php
+++ b/src/Testing/Resources/GenerativeModelTestResource.php
@@ -47,11 +47,15 @@ final class GenerativeModelTestResource implements GenerativeModelContract
 
     public function withSafetySetting(SafetySetting $safetySetting): self
     {
-        return $this->record(method: __FUNCTION__, args: func_get_args(), model: $this->model);
+        $this->recordFunctionCall(method: __FUNCTION__, args: func_get_args(), model: $this->model);
+
+        return $this;
     }
 
     public function withGenerationConfig(GenerationConfig $generationConfig): self
     {
-        return $this->record(method: __FUNCTION__, args: func_get_args(), model: $this->model);
+        $this->recordFunctionCall(method: __FUNCTION__, args: func_get_args(), model: $this->model);
+
+        return $this;
     }
 }

--- a/src/Testing/Resources/GenerativeModelTestResource.php
+++ b/src/Testing/Resources/GenerativeModelTestResource.php
@@ -7,6 +7,8 @@ namespace Gemini\Testing\Resources;
 use Gemini\Contracts\Resources\GenerativeModelContract;
 use Gemini\Data\Blob;
 use Gemini\Data\Content;
+use Gemini\Data\GenerationConfig;
+use Gemini\Data\SafetySetting;
 use Gemini\Resources\ChatSession;
 use Gemini\Resources\GenerativeModel;
 use Gemini\Responses\GenerativeModel\CountTokensResponse;
@@ -39,6 +41,16 @@ final class GenerativeModelTestResource implements GenerativeModelContract
     }
 
     public function startChat(array $history = []): ChatSession
+    {
+        return $this->record(method: __FUNCTION__, args: func_get_args(), model: $this->model);
+    }
+
+    public function withSafetySetting(SafetySetting $safetySetting): self
+    {
+        return $this->record(method: __FUNCTION__, args: func_get_args(), model: $this->model);
+    }
+
+    public function withGenerationConfig(GenerationConfig $generationConfig): self
     {
         return $this->record(method: __FUNCTION__, args: func_get_args(), model: $this->model);
     }

--- a/tests/Testing/Resources/GenerativeModelTestResource.php
+++ b/tests/Testing/Resources/GenerativeModelTestResource.php
@@ -76,20 +76,20 @@ it('records a "withGenerationConfig" function call', function () {
 });
 
 it('records both content request and function call', function () {
-	$fake = new ClientFake([
-		GenerateContentResponse::fake(),
-	]);
+    $fake = new ClientFake([
+        GenerateContentResponse::fake(),
+    ]);
 
-	$generationConfig = new GenerationConfig;
+    $generationConfig = new GenerationConfig;
 
-	$fake->geminiPro()->withGenerationConfig($generationConfig)->generateContent('Hello');
+    $fake->geminiPro()->withGenerationConfig($generationConfig)->generateContent('Hello');
 
-	$fake->geminiPro()->assertSent(function (string $method, array $parameters) {
-		return $method === 'generateContent' &&
-			$parameters[0] === 'Hello';
-	});
-	$fake->geminiPro()->assertFunctionCalled(function (string $method, array $parameters) use ($generationConfig) {
-		return $method === 'withGenerationConfig' &&
-			$parameters[0] === $generationConfig;
-	});
+    $fake->geminiPro()->assertSent(function (string $method, array $parameters) {
+        return $method === 'generateContent' &&
+            $parameters[0] === 'Hello';
+    });
+    $fake->geminiPro()->assertFunctionCalled(function (string $method, array $parameters) use ($generationConfig) {
+        return $method === 'withGenerationConfig' &&
+            $parameters[0] === $generationConfig;
+    });
 });

--- a/tests/Testing/Resources/GenerativeModelTestResource.php
+++ b/tests/Testing/Resources/GenerativeModelTestResource.php
@@ -74,3 +74,22 @@ it('records a "withGenerationConfig" function call', function () {
             $parameters[0] === $generationConfig;
     });
 });
+
+it('records both content request and function call', function () {
+	$fake = new ClientFake([
+		GenerateContentResponse::fake(),
+	]);
+
+	$generationConfig = new GenerationConfig;
+
+	$fake->geminiPro()->withGenerationConfig($generationConfig)->generateContent('Hello');
+
+	$fake->geminiPro()->assertSent(function (string $method, array $parameters) {
+		return $method === 'generateContent' &&
+			$parameters[0] === 'Hello';
+	});
+	$fake->geminiPro()->assertFunctionCalled(function (string $method, array $parameters) use ($generationConfig) {
+		return $method === 'withGenerationConfig' &&
+			$parameters[0] === $generationConfig;
+	});
+});

--- a/tests/Testing/Resources/GenerativeModelTestResource.php
+++ b/tests/Testing/Resources/GenerativeModelTestResource.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Gemini\Data\GenerationConfig;
+use Gemini\Data\SafetySetting;
+use Gemini\Enums\HarmBlockThreshold;
+use Gemini\Enums\HarmCategory;
 use Gemini\Responses\GenerativeModel\CountTokensResponse;
 use Gemini\Responses\GenerativeModel\GenerateContentResponse;
 use Gemini\Testing\ClientFake;
@@ -42,5 +46,31 @@ it('records a stream generate content request', function () {
     $fake->geminiPro()->assertSent(function (string $method, array $parameters) {
         return $method === 'streamGenerateContent' &&
             $parameters[0] === 'Hello';
+    });
+});
+
+it('records a "withSafetySetting" function call', function () {
+    $fake = new ClientFake;
+
+    $safetySetting = new SafetySetting(HarmCategory::HARM_CATEGORY_DANGEROUS, HarmBlockThreshold::BLOCK_ONLY_HIGH);
+
+    $fake->geminiPro()->withSafetySetting($safetySetting);
+
+    $fake->geminiPro()->assertFunctionCalled(function (string $method, array $parameters) use ($safetySetting) {
+        return $method === 'withSafetySetting' &&
+            $parameters[0] === $safetySetting;
+    });
+});
+
+it('records a "withGenerationConfig" function call', function () {
+    $fake = new ClientFake;
+
+    $generationConfig = new GenerationConfig;
+
+    $fake->geminiPro()->withGenerationConfig($generationConfig);
+
+    $fake->geminiPro()->assertFunctionCalled(function (string $method, array $parameters) use ($generationConfig) {
+        return $method === 'withGenerationConfig' &&
+            $parameters[0] === $generationConfig;
     });
 });


### PR DESCRIPTION
This PR brings alignment between `GenerativeModel` and `GenerativeModelTestResource` by adding `withSafetySetting()` and `withGenerationConfig()` methods to `GenerativeModelContract`. Since these methods do not perform requests I also introduced a way to assert function calls so this can be tested.

After this is merged I can open a PR to `beta` branch.

Made sure that `composer test` is passing.