### PR TITLE
Ability to decode json as associative array

### DIFF
--- a/src/Responses/GenerativeModel/GenerateContentResponse.php
+++ b/src/Responses/GenerativeModel/GenerateContentResponse.php
@@ -90,9 +90,9 @@ final class GenerateContentResponse implements ResponseContract
     /**
      * A quick accessor equivalent to `json_decode($candidates[0].parts[0].text)`
      */
-    public function json(): mixed
+    public function json(bool $associative = false, int $flags = 0): mixed
     {
-        return json_decode($this->text());
+        return json_decode($this->text(), associative: $associative, flags: $flags);
     }
 
     /**


### PR DESCRIPTION
With this change it is now possible to use `->json(associative: true)` and get an associative array as opposed to `stdObject`. Also support for passing flags. There should be no breaking changes.

Lint and tests are passing.