### PR TITLE
Add missing DataFormat and support propertyOrdering for Object Schema

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache/files
           key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache/files
           key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/src/Data/DataFormat.php
+++ b/src/Data/DataFormat.php
@@ -15,5 +15,6 @@ enum DataFormat: string
     case INT64 = 'int64';
 
     // for String
-    case ENUM = 'enum';
+    case ENUM     = 'enum';
+    case DATETIME = 'date-time';
 }

--- a/src/Data/Schema.php
+++ b/src/Data/Schema.php
@@ -26,6 +26,7 @@ class Schema implements Arrayable
      * @param  string|null  $minItems  Minimum number of the elements for Type.ARRAY.
      * @param  array<string, Schema>|null  $properties  Properties of Type.OBJECT.
      * @param  array<string>|null  $required  Required properties of Type.OBJECT.
+     * @param  array<string>|null  $propertyOrdering  PropertyOrdering of Type.OBJECT.
      * @param  Schema|null  $items  Schema of the elements of Type.ARRAY.
      */
     public function __construct(
@@ -38,6 +39,7 @@ class Schema implements Arrayable
         public readonly ?string $minItems = null,
         public readonly ?array $properties = null,
         public readonly ?array $required = null,
+        public readonly ?array $propertyOrdering = null,
         public readonly ?Schema $items = null
     ) {}
 
@@ -54,6 +56,7 @@ class Schema implements Arrayable
                 'minItems' => $this->minItems,
                 'properties' => array_map(fn ($property) => $property->toArray(), $this->properties ?? []),
                 'required' => $this->required,
+                'propertyOrdering' => $this->propertyOrdering,
                 'items' => $this->items?->toArray(),
             ]
         );

--- a/src/Responses/GenerativeModel/GenerateContentResponse.php
+++ b/src/Responses/GenerativeModel/GenerateContentResponse.php
@@ -90,9 +90,9 @@ final class GenerateContentResponse implements ResponseContract
     /**
      * A quick accessor equivalent to `json_decode($candidates[0].parts[0].text)`
      */
-    public function json(): mixed
+    public function json(bool $associative = false, int $flags = 0): mixed
     {
-        return json_decode($this->text());
+        return json_decode($this->text(), associative: $associative, flags: $flags);
     }
 
     /**


### PR DESCRIPTION
Add support of `propertyOrdering` param described [here](https://ai.google.dev/gemini-api/docs/structured-output?lang=rest).
I've also added `date-time` DataFormat for string described [here](https://ai.google.dev/gemini-api/docs/structured-output?lang=rest)