### PR TITLE
Define require psr http implementation to make php-http/discovery auto discovery working

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,9 @@
   ],
   "require": {
     "php": "^8.1.0",
-    "php-http/discovery": "^1.19.2"
+    "php-http/discovery": "^1.19.2",
+    "psr/http-client-implementation": "*",
+    "psr/http-factory-implementation": "*"
   },
   "require-dev": {
     "guzzlehttp/guzzle": "^7.8.1",


### PR DESCRIPTION

See https://github.com/php-http/discovery?tab=readme-ov-file#usage-as-a-library-author