### PR TITLE
fix: New models from Google could be without descriptions

### DIFF
--- a/src/Data/Model.php
+++ b/src/Data/Model.php
@@ -17,7 +17,7 @@ final class Model implements Arrayable
      * @param  string  $name  The resource name of the Model.
      * @param  string  $version  The version number of the model.
      * @param  string  $displayName  The human-readable name of the model. E.g. "ChatSession Bison".
-     * @param  string  $description  A short description of the model.
+     * @param  string|null  $description  A short description of the model.
      * @param  int  $inputTokenLimit  Maximum number of input tokens allowed for this model.
      * @param  int  $outputTokenLimit  Maximum number of output tokens available for this model.
      * @param  array<string>  $supportedGenerationMethods  The model's supported generation methods.
@@ -31,7 +31,7 @@ final class Model implements Arrayable
         public readonly string $name,
         public readonly string $version,
         public readonly string $displayName,
-        public readonly string $description,
+        public readonly ?string $description,
         public readonly int $inputTokenLimit,
         public readonly int $outputTokenLimit,
         public readonly array $supportedGenerationMethods,
@@ -43,7 +43,7 @@ final class Model implements Arrayable
     ) {}
 
     /**
-     * @param  array{ name: string, version: string, displayName: string, description: string, inputTokenLimit: int, outputTokenLimit: int, supportedGenerationMethods: array<string>, baseModelId: ?string, temperature: ?float, maxTemperature: ?float, topP: ?float, topK: ?int }  $attributes
+     * @param  array{ name: string, version: string, displayName: string, description: string|null, inputTokenLimit: int, outputTokenLimit: int, supportedGenerationMethods: array<string>, baseModelId: ?string, temperature: ?float, maxTemperature: ?float, topP: ?float, topK: ?int }  $attributes
      */
     public static function from(array $attributes): self
     {
@@ -51,7 +51,7 @@ final class Model implements Arrayable
             name: $attributes['name'],
             version: $attributes['version'],
             displayName: $attributes['displayName'],
-            description: $attributes['description'] ?? 'No description provided.',
+            description: $attributes['description'] ?? null,
             inputTokenLimit: $attributes['inputTokenLimit'],
             outputTokenLimit: $attributes['outputTokenLimit'],
             supportedGenerationMethods: $attributes['supportedGenerationMethods'],

--- a/src/Data/Model.php
+++ b/src/Data/Model.php
@@ -51,7 +51,7 @@ final class Model implements Arrayable
             name: $attributes['name'],
             version: $attributes['version'],
             displayName: $attributes['displayName'],
-            description: $attributes['description'],
+            description: $attributes['description'] ?? 'No description provided.',
             inputTokenLimit: $attributes['inputTokenLimit'],
             outputTokenLimit: $attributes['outputTokenLimit'],
             supportedGenerationMethods: $attributes['supportedGenerationMethods'],


### PR DESCRIPTION
```
TypeError: Gemini\Data\Model::__construct(): Argument #4 ($description) must be of type string, null given, called in vendor/google-gemini-php/client/src/Data/Model.php on line 50 in Gemini\Data\Model->__construct() (line 30 of vendor/google-gemini-php/client/src/Data/Model.php).
```