### PR TITLE
Hanlding avgLogprobs infinity

### DIFF
--- a/src/Data/Candidate.php
+++ b/src/Data/Candidate.php
@@ -61,6 +61,10 @@ final class Candidate implements Arrayable
             default => null,
         };
 
+        if (($attributes['avgLogprobs'] ?? null) === 'Infinity') { // @phpstan-ignore-line
+            $attributes['avgLogprobs'] = INF;
+        }
+
         return new self(
             content: $content,
             finishReason: $finishReason,


### PR DESCRIPTION
I've been playing around with Gemini 2.0 and keep running into an issue where avgLogprobs is sometimes returned as string 'Infinity'.