### PR TITLE
docs(readme): fix gemini class import error

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,10 @@ Interact with Gemini's API:
 ```php
 use Gemini\Enums\ModelVariation;
 use Gemini\GeminiHelper;
+use Gemini;
 
 $yourApiKey = getenv('YOUR_API_KEY');
-$client = \Gemini::client($yourApiKey);
+$client = Gemini::client($yourApiKey);
 
 $result = $client->generativeModel(model: 'gemini-2.0-flash')->generateContent('Hello');
 $result->text(); // Hello! How can I assist you today?
@@ -116,18 +117,11 @@ $result = $client->generativeModel(
 $result->text(); // Hello! How can I assist you today?
 ```
 
-**Note**: You can also add `use Gemini;` as import to use `Gemini::client($yourApiKey)` without a backslash.
-```php
-use Gemini\Enums\ModelVariation;
-use Gemini;
-
-$yourApiKey = getenv('YOUR_API_KEY');
-$client = Gemini::client($yourApiKey);
-```
-
 If necessary, it is possible to configure and create a separate client.
 
 ```php
+use Gemini;
+
 $yourApiKey = getenv('YOUR_API_KEY');
 
 $client = Gemini::factory()
@@ -151,6 +145,8 @@ For a complete list of supported input formats and methods in Gemini API v1, see
 Generate a response from the model given an input message.
 
 ```php
+use Gemini;
+
 $yourApiKey = getenv('YOUR_API_KEY');
 $client = Gemini::client($yourApiKey);
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ use Gemini\Enums\ModelVariation;
 use Gemini\GeminiHelper;
 
 $yourApiKey = getenv('YOUR_API_KEY');
-$client = Gemini::client($yourApiKey);
+$client = \Gemini::client($yourApiKey);
 
 $result = $client->generativeModel(model: 'gemini-2.0-flash')->generateContent('Hello');
 $result->text(); // Hello! How can I assist you today?
@@ -114,6 +114,15 @@ $result = $client->generativeModel(
     ), // models/gemini-2.5-flash-preview-04-17
 );
 $result->text(); // Hello! How can I assist you today?
+```
+
+**Note**: You can also add `use Gemini;` as import to use `Gemini::client($yourApiKey)` without a backslash.
+```php
+use Gemini\Enums\ModelVariation;
+use Gemini;
+
+$yourApiKey = getenv('YOUR_API_KEY');
+$client = Gemini::client($yourApiKey);
 ```
 
 If necessary, it is possible to configure and create a separate client.


### PR DESCRIPTION
This fixes the #108 issue.

- Fixed Gemini class not found error by correcting import usage and suggesting use of `use Gemini;`
- I've tested both the updated imports and are working fine.

Thanks, @Plytas, for the help.