### PR TITLE
citationSources attribute can be unset

### DIFF
--- a/src/Data/CitationMetadata.php
+++ b/src/Data/CitationMetadata.php
@@ -21,7 +21,7 @@ final class CitationMetadata implements Arrayable
     ) {}
 
     /**
-     * @param  array{ citationSources: array{ array{ startIndex: int, endIndex: int, uri: ?string, license: ?string } } }  $attributes
+     * @param  array{ citationSources: ?array{ array{ startIndex: int, endIndex: int, uri: ?string, license: ?string } } }  $attributes
      */
     public static function from(array $attributes): self
     {

--- a/src/Data/CitationMetadata.php
+++ b/src/Data/CitationMetadata.php
@@ -26,10 +26,10 @@ final class CitationMetadata implements Arrayable
     public static function from(array $attributes): self
     {
         return new self(
-            citationSources: array_map(
+            citationSources: isset($attributes['citationSources']) ? array_map(
                 static fn (array $source): CitationSource => CitationSource::from($source),
                 $attributes['citationSources'],
-            )
+            ) : null
         );
     }
 

--- a/src/Data/CitationMetadata.php
+++ b/src/Data/CitationMetadata.php
@@ -21,15 +21,15 @@ final class CitationMetadata implements Arrayable
     ) {}
 
     /**
-     * @param  array{ citationSources: ?array{ array{ startIndex: int, endIndex: int, uri: ?string, license: ?string } } }  $attributes
+     * @param  array{ citationSources?: array{ array{ startIndex: int, endIndex: int, uri: ?string, license: ?string } } }  $attributes
      */
     public static function from(array $attributes): self
     {
         return new self(
-            citationSources: isset($attributes['citationSources']) ? array_map(
+            citationSources: array_map(
                 static fn (array $source): CitationSource => CitationSource::from($source),
-                $attributes['citationSources'],
-            ) : null
+                $attributes['citationSources'] ?? [],
+            )
         );
     }
 


### PR DESCRIPTION
## citationSources attribute can be unset
### Problem
Sometimes, `citationSources` can be undefined. Here is an example of an exception I received in my app : 

```
[2025-06-08 11:35:18] local.ERROR: Undefined array key "citationSources" {"exception":"[object] (ErrorException(code: 0): Undefined array key \"citationSources\" at /var/www/html/vendor/google-gemini-php/client/src/Data/CitationMetadata.php:31)
[stacktrace]
#0 /var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(256): Illuminate\\Foundation\\Bootstrap\\HandleExceptions->handleError(2, 'Undefined array...', '/var/www/html/v...', 31)
#1 /var/www/html/vendor/google-gemini-php/client/src/Data/CitationMetadata.php(31): Illuminate\\Foundation\\Bootstrap\\HandleExceptions->Illuminate\\Foundation\\Bootstrap\\{closure}(2, 'Undefined array...', '/var/www/html/v...', 31)
#2 /var/www/html/vendor/google-gemini-php/client/src/Data/Candidate.php(61): Gemini\\Data\\CitationMetadata::from(Array)
#3 /var/www/html/vendor/google-gemini-php/client/src/Responses/GenerativeModel/GenerateContentResponse.php(106): Gemini\\Data\\Candidate::from(Array)
#4 [internal function]: Gemini\\Responses\\GenerativeModel\\GenerateContentResponse::Gemini\\Responses\\GenerativeModel\\{closure}(Array)
#5 /var/www/html/vendor/google-gemini-php/client/src/Responses/GenerativeModel/GenerateContentResponse.php(105): array_map(Object(Closure), Array)
```

### Solution
- Verify that `citationSources` is set before accessing it

closes #118
