### PR TITLE
Add FilesContract to Client

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -6,6 +6,7 @@ namespace Gemini;
 
 use BackedEnum;
 use Gemini\Contracts\ClientContract;
+use Gemini\Contracts\Resources\FilesContract;
 use Gemini\Contracts\Resources\GenerativeModelContract;
 use Gemini\Contracts\TransporterContract;
 use Gemini\Enums\ModelType;
@@ -69,7 +70,7 @@ final class Client implements ClientContract
      *
      * @link https://ai.google.dev/api/files
      */
-    public function files(): Files
+    public function files(): FilesContract
     {
         return new Files($this->transporter);
     }

--- a/src/Contracts/ClientContract.php
+++ b/src/Contracts/ClientContract.php
@@ -7,6 +7,7 @@ namespace Gemini\Contracts;
 use BackedEnum;
 use Gemini\Contracts\Resources\ChatSessionContract;
 use Gemini\Contracts\Resources\EmbeddingModalContract;
+use Gemini\Contracts\Resources\FilesContract;
 use Gemini\Contracts\Resources\GenerativeModelContract;
 use Gemini\Contracts\Resources\ModelContract;
 
@@ -29,4 +30,6 @@ interface ClientContract
     public function embeddingModel(BackedEnum|string $model): EmbeddingModalContract;
 
     public function chat(BackedEnum|string $model): ChatSessionContract;
+
+    public function files(): FilesContract;
 }


### PR DESCRIPTION
Add the files() method with the FilesContract return type to the client.

All other methods return contracts, was this one not included on purpose perhaps?