### PR TITLE
Added `urlContext` support

### DIFF
--- a/src/Data/Tool.php
+++ b/src/Data/Tool.php
@@ -26,7 +26,7 @@ final class Tool implements Arrayable
         public ?GoogleSearchRetrieval $googleSearchRetrieval = null,
         public ?CodeExecution $codeExecution = null,
         public ?GoogleSearch $googleSearch = null,
-		public ?UrlContext $urlContext = null,
+        public ?UrlContext $urlContext = null,
     ) {}
 
     public function toArray(): array
@@ -52,9 +52,9 @@ final class Tool implements Arrayable
             $data['google_search'] = $this->googleSearch->toArray();
         }
 
-		if ($this->urlContext !== null) {
-			$data['url_context'] = $this->urlContext->toArray();
-		}
+        if ($this->urlContext !== null) {
+            $data['url_context'] = $this->urlContext->toArray();
+        }
 
         return $data;
     }

--- a/src/Data/Tool.php
+++ b/src/Data/Tool.php
@@ -19,12 +19,14 @@ final class Tool implements Arrayable
      * @param  GoogleSearchRetrieval|null  $googleSearchRetrieval  Optional. Retrieval tool that is powered by Google search.
      * @param  CodeExecution|null  $codeExecution  Optional. Enables the model to execute code as part of generation.
      * @param  GoogleSearch|null  $googleSearch  Optional. GoogleSearch tool type. Tool to support Google Search in Model. Powered by Google.
+     * @param  UrlContext|null  $urlContext  Optional. Tool to support URL context retrieval.
      */
     public function __construct(
         public ?array $functionDeclarations = null,
         public ?GoogleSearchRetrieval $googleSearchRetrieval = null,
         public ?CodeExecution $codeExecution = null,
         public ?GoogleSearch $googleSearch = null,
+		public ?UrlContext $urlContext = null,
     ) {}
 
     public function toArray(): array
@@ -49,6 +51,10 @@ final class Tool implements Arrayable
         if ($this->googleSearch !== null) {
             $data['google_search'] = $this->googleSearch->toArray();
         }
+
+		if ($this->urlContext !== null) {
+			$data['url_context'] = $this->urlContext->toArray();
+		}
 
         return $data;
     }

--- a/src/Data/UrlContext.php
+++ b/src/Data/UrlContext.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gemini\Data;
+
+use stdClass;
+
+/**
+ * This type has no fields.
+ * Tool to support URL context retrieval.
+ *
+ * https://ai.google.dev/api/caching#UrlContext
+ */
+final class UrlContext
+{
+    public function __construct(
+    ) {}
+
+    public static function from(): self
+    {
+        return new self;
+    }
+
+    public function toArray(): stdClass
+    {
+        return new stdClass;
+    }
+}


### PR DESCRIPTION
Example:

```php
<?php

use Gemini\Data\Tool;
use Gemini\Data\UrlContext;

$response = $gemini->generativeModel('gemini-2.0-flash')
    ->withTool(
        tool: new Tool(
            urlContext: new UrlContext(),
        )
    )
)->generateContent("https://php.net");
```